### PR TITLE
Add VoyTechnology as maintainer of virtualbox.

### DIFF
--- a/members.tf
+++ b/members.tf
@@ -17,3 +17,8 @@ resource "github_membership" "Rio_Bard" {
   username = "riobard"
   role     = "member"
 }
+
+resource "github_membership" "Wojtek_Bednarzak" {
+  username = "voytechnology"
+  role     = "member"
+}

--- a/virtualbox.tf
+++ b/virtualbox.tf
@@ -39,3 +39,9 @@ resource "github_team_membership" "virtualbox-Rio_Bard" {
   username = "riobard"
   role     = "maintainer"
 }
+
+resource "github_team_membership" "virtualbox-Wojtek_Bednarzak" {
+  team_id  = "${github_team.virtualbox.id}"
+  username = "VoyTechnology"
+  role     = "maintainer"
+}


### PR DESCRIPTION
I would like to help with managing to the `terraform-virtualbox-provider`, as I have a few contributions to the repository already, and the access would allow me to add tags and create milestones which would help with the organisation of the repository.

Perhaps I don't need the general membership.